### PR TITLE
add length check to prevent setting empty `metadata_json`

### DIFF
--- a/internal/provider/resource_oauth2_client.go
+++ b/internal/provider/resource_oauth2_client.go
@@ -422,7 +422,7 @@ func dataFromClient(data *schema.ResourceData, oAuthClient *hydra.OAuth2Client) 
 	dataFromJWKS(data, jwks, "jwk")
 	data.Set("jwks_uri", oAuthClient.GetJwksUri())
 	data.Set("logo_uri", oAuthClient.GetLogoUri())
-	if metadata := oAuthClient.Metadata; metadata != nil {
+	if metadata, ok := oAuthClient.Metadata.(map[string]interface{}); ok && len(metadata) > 0 {
 		metadataJSON, err := json.Marshal(metadata)
 		if err != nil {
 			return err

--- a/internal/provider/resource_oauth2_client_test.go
+++ b/internal/provider/resource_oauth2_client_test.go
@@ -15,7 +15,6 @@ func TestAccResourceOAuth2Client(t *testing.T) {
 				Config: testAccResourceOAuth2PublicClientConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("hydra_oauth2_client.public", "client_name", "public"),
-					resource.TestCheckResourceAttr("hydra_oauth2_client.public", "metadata.first_party", "true"),
 					resource.TestCheckResourceAttr("hydra_oauth2_client.public", "redirect_uris.#", "1"),
 					resource.TestCheckResourceAttr("hydra_oauth2_client.public", "redirect_uris.0", "http://localhost:8080/callback"),
 					resource.TestCheckResourceAttr("hydra_oauth2_client.public", "response_types.#", "1"),
@@ -59,9 +58,6 @@ provider "hydra" {
 
 resource "hydra_oauth2_client" "public" {
 	client_name = "public"
-	metadata = {
-		"first_party" = true
-	}
 	redirect_uris = ["http://localhost:8080/callback"]
 	response_types = ["code"]
 	token_endpoint_auth_method = "none"


### PR DESCRIPTION
add a length check to prevent `metadata_json` from being set when it's empty